### PR TITLE
INT-105: Additional Default Metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ These metrics are published by default.
 | requests.total | None |
 | requests.current | None |
 | server.zone.requests | server.zone.name |
+| server.zone.responses.1xx | server.zone.name |
+| server.zone.responses.2xx | server.zone.name |
+| server.zone.responses.3xx | server.zone.name |
 | server.zone.responses.4xx | server.zone.name |
 | server.zone.responses.5xx | server.zone.name |
 | server.zone.responses.total | server.zone.name |
@@ -78,6 +81,9 @@ These metrics are published by default.
 | caches.size | cache.name |
 | caches.size.max | cache.name |
 | upstreams.requests | upstream.name, upstream.peer.name |
+| upstreams.responses.1xx | upstream.name, upstream.peer.name |
+| upstreams.responses.2xx | upstream.name, upstream.peer.name |
+| upstreams.responses.3xx | upstream.name, upstream.peer.name |
 | upstreams.responses.4xx | upstream.name, upstream.peer.name |
 | upstreams.responses.5xx | upstream.name, upstream.peer.name |
 | upstreams.responses.total | upstream.name, upstream.peer.name |
@@ -99,9 +105,6 @@ To include these metrics, add `ServerZone true` to the plugin configuration, e.g
 ##### Metrics
 * server.zone.processing
 * server.zone.discarded
-* server.zone.responses.1xx
-* server.zone.responses.2xx
-* server.zone.responses.3xx
 
 ### Memory Zone Metrics
 All memory zone metrics are decorated with dimension `memory.zone.name` .
@@ -129,9 +132,6 @@ To include these metrics, add `Upstream true` to the plugin configuration, e.g.
 ```
 ##### Metrics
 * upstreams.active
-* upstreams.responses.1xx
-* upstreams.responses.2xx
-* upstreams.responses.3xx
 * upstreams.fails
 * upstreams.unavailable
 * upstreams.health.checks.checks

--- a/plugin/nginx_plus_collectd.py
+++ b/plugin/nginx_plus_collectd.py
@@ -136,6 +136,9 @@ DEFAULT_REQUESTS_METRICS = [
 
 DEFAULT_SERVER_ZONE_METRICS = [
     MetricDefinition('server.zone.requests', 'counter', 'requests'),
+    MetricDefinition('server.zone.responses.1xx', 'counter', 'responses.1xx'),
+    MetricDefinition('server.zone.responses.2xx', 'counter', 'responses.2xx'),
+    MetricDefinition('server.zone.responses.3xx', 'counter', 'responses.3xx'),
     MetricDefinition('server.zone.responses.4xx', 'counter', 'responses.4xx'),
     MetricDefinition('server.zone.responses.5xx', 'counter', 'responses.5xx'),
     MetricDefinition('server.zone.responses.total', 'counter', 'responses.total'),
@@ -145,6 +148,9 @@ DEFAULT_SERVER_ZONE_METRICS = [
 
 DEFAULT_UPSTREAM_METRICS = [
     MetricDefinition('upstreams.requests', 'counter', 'requests'),
+    MetricDefinition('upstreams.responses.1xx', 'counter', 'responses.1xx'),
+    MetricDefinition('upstreams.responses.2xx', 'counter', 'responses.2xx'),
+    MetricDefinition('upstreams.responses.3xx', 'counter', 'responses.3xx'),
     MetricDefinition('upstreams.responses.4xx', 'counter', 'responses.4xx'),
     MetricDefinition('upstreams.responses.5xx', 'counter', 'responses.5xx'),
     MetricDefinition('upstreams.responses.total', 'counter', 'responses.total'),
@@ -161,10 +167,7 @@ DEFAULT_CACHE_METRICS = [
 
 SERVER_ZONE_METRICS = [
     MetricDefinition('server.zone.processing', 'counter', 'processing'),
-    MetricDefinition('server.zone.discarded', 'counter', 'discarded'),
-    MetricDefinition('server.zone.responses.1xx', 'counter', 'responses.1xx'),
-    MetricDefinition('server.zone.responses.2xx', 'counter', 'responses.2xx'),
-    MetricDefinition('server.zone.responses.3xx', 'counter', 'responses.3xx')
+    MetricDefinition('server.zone.discarded', 'counter', 'discarded')
 ]
 
 MEMORY_ZONE_METRICS = [
@@ -181,9 +184,6 @@ UPSTREAM_METRICS = [
 # Metrics taken from each upstream peer
 UPSTREAM_PEER_METRICS = [
     MetricDefinition('upstreams.active', 'counter', 'active'),
-    MetricDefinition('upstreams.responses.1xx', 'counter', 'responses.1xx'),
-    MetricDefinition('upstreams.responses.2xx', 'counter', 'responses.2xx'),
-    MetricDefinition('upstreams.responses.3xx', 'counter', 'responses.3xx'),
     MetricDefinition('upstreams.fails', 'counter', 'fails'),
     MetricDefinition('upstreams.unavailable', 'counter', 'unavail'),
     MetricDefinition('upstreams.health.checks.checks', 'counter', 'health_checks.checks'),


### PR DESCRIPTION
Made 1xx, 2xx and 3xx response counters for server zones and upstreams default metrics to support requested charts.